### PR TITLE
aggrégation table immatriculation_group_by_codegeo au 31-12-2024

### DIFF
--- a/models/intermediate/intermediate_immatriculation_full_date_2024_12-31.sql
+++ b/models/intermediate/intermediate_immatriculation_full_date_2024_12-31.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM {{ ref('intermediate_immatriculation_full') }}
+WHERE date_arrete = '2024-12-31'

--- a/models/intermediate/intermediate_immatriculation_group_by_codegeo.sql
+++ b/models/intermediate/intermediate_immatriculation_group_by_codegeo.sql
@@ -3,5 +3,5 @@
     ,SUM (NB_VP) AS total_VP
     ,SUM (NB_VP_RECHARGEABLES_EL) AS total_VP_rechargeables
     ,SUM (RATIO_VP_RECHARGEABLES_EL_PCT) AS ratio_VP_rechargeables
-    FROM {{ ref('intermediate_immatriculation') }}
+    FROM {{ ref('intermediate_immatriculation_full_date_2024_12-31') }}
     GROUP BY CODGEO


### PR DESCRIPTION
aggrégation table immatriculation_group_by_codegeo au 31-12-2024

- création de la table intermediaire {{ ref('intermediate_immatriculation_full_date_2024_12-31') }} avec un filtre sur la date au 31-12-2024
- mise à jour de la table {{ ref('intermediate_immatriculation_group_by_codegeo') }} sur le meme filtre
- mise à jour de la table mart {{ ref('analyse_immat_bornes_dispos') }} sur le meme filtre